### PR TITLE
adds index on status

### DIFF
--- a/data/queue_default.sql
+++ b/data/queue_default.sql
@@ -9,6 +9,6 @@ CREATE TABLE IF NOT EXISTS `queue_default` (
   `finished` datetime NULL DEFAULT NULL,
   `message` text DEFAULT NULL,
   `trace` text,
-  PRIMARY KEY (`id`)
+  PRIMARY KEY (`id`),
+  KEY `status` (`status`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;
-


### PR DESCRIPTION
by adding an index on the 'status' field 'long' running queries are prevented... according from the long query log

not sure why that would happen only with an tinyint field and not with the other fields that the queue uses to pull jobs... 

```
SELECT * FROM queue_default WHERE status = 1 AND queue = 'main' AND scheduled <= '2014-01-02 21:14:09' ORDER BY scheduled ASC LIMIT 1 FOR UPDATE;
```
