### PR TITLE
check for presence of ObjectManager in ObjectManagerAwareInterface job before clearing

### DIFF
--- a/src/SlmQueueDoctrine/Strategy/ClearObjectManagerStrategy.php
+++ b/src/SlmQueueDoctrine/Strategy/ClearObjectManagerStrategy.php
@@ -29,7 +29,7 @@ class ClearObjectManagerStrategy extends AbstractStrategy
         /** @var ObjectManagerAwareInterface $job */
         $job = $event->getJob();
 
-        if ($job instanceof ObjectManagerAwareInterface) {
+        if ($job instanceof ObjectManagerAwareInterface && $job->getObjectManager()) {
             $job->getObjectManager()->clear();
         }
     }


### PR DESCRIPTION
ObjectManagerAwareInterface::getObjectManager() may return null
