### PR TITLE
Use more efficient indices in sample configuration

### DIFF
--- a/data/queue_default.sql
+++ b/data/queue_default.sql
@@ -10,5 +10,6 @@ CREATE TABLE IF NOT EXISTS `queue_default` (
   `message` text DEFAULT NULL,
   `trace` text,
   PRIMARY KEY (`id`),
-  KEY `status` (`status`)
+  KEY `pop` (`status`,`queue`,`scheduled`),
+  KEY `prune` (`status`,`queue`,`finished`)
 ) ENGINE=InnoDB  DEFAULT CHARSET=utf8;


### PR DESCRIPTION
When you use the queue to schedule tasks that occur in the feature, the queue can easily grow large. Using correct indices becomes important at that point. 

The current index only filters on status. The proposed two indices are tailored to the tasks the worker performs most: popping an item from the queue and pruning it 
