### PR TITLE
Update PHP and doctrine/dbal dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
                 php-version:
                     - "7.4"
                     - "8.0"
+                    - "8.1"
                 dependencies:
                     - "highest"
                     - "lowest"

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 composer.lock
 vendor
 .phpunit.result.cache
+.idea

--- a/README.md
+++ b/README.md
@@ -16,13 +16,7 @@ Note: it's necessary require the doctrine package in composer.json file.
 Installation
 ------------
 
-Add the following line into your `composer.json` file:
-
-```json
-"require": {
-    "slm/queue-doctrine": "^3.0"
-}
-```
+Run `composer require slm/queue-doctrine`.
 
 If you have the [laminas/laminas-component-installer](https://github.com/laminas/laminas-component-installer) package installed, it will ask you to enable the module (and `SlmQueue`), both in Laminas and Mezzio. Otherwise, add the module to the list:
 * in Laminas MVC, enable the module by adding `SlmQueueDoctrine` in your application.config.php file.

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
         {
             "name": "Stefan Kleff",
             "email": "s.kleff@goalio.de",
-            "homepage": "http://www.goalio.de"
+            "homepage": "https://www.goalio.de"
         },
         {
             "name": "Bas Kamer",
@@ -84,5 +84,10 @@
             "@composer test --working-dir=tests/laminas-runner",
             "@composer test --working-dir=tests/mezzio-runner"
         ]
+    },
+    "config": {
+        "platform": {
+            "php": "7.4.0"
+        }
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -26,17 +26,16 @@
         }
     ],
     "require": {
-        "php": "^7.4 || ~8.0",
+        "php": ">=7.4",
         "laminas/laminas-eventmanager": "^3.3",
         "laminas/laminas-router": "^3.4",
         "laminas/laminas-servicemanager": "^3.6",
         "laminas/laminas-stdlib": "^3.3",
         "slm/queue": "^3.0",
-        "doctrine/dbal": "^2.12",
+        "doctrine/dbal": "^3.0",
         "doctrine/annotations": "^1.8",
         "laminas/laminas-config": "^3.4",
         "laminas/laminas-cli": "^1.1.1"
-        
     },
     "require-dev": {
         "ext-sqlite3": "*",
@@ -48,8 +47,8 @@
         "laminas/laminas-serializer": "^2.10",
         "laminas/laminas-mvc": "^3.3",
         "doctrine/orm": "^2.10",
-        "phpunit/phpunit": "^9",
-        "squizlabs/php_codesniffer": "3.*"
+        "phpunit/phpunit": "^9.0",
+        "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {
         "doctrine/doctrine-orm-module": "If you use Doctrine in combination with Laminas",

--- a/composer.json
+++ b/composer.json
@@ -47,7 +47,7 @@
         "laminas/laminas-serializer": "^2.10",
         "laminas/laminas-mvc": "^3.3",
         "doctrine/orm": "^2.10",
-        "phpunit/phpunit": "^9.0",
+        "phpunit/phpunit": "^9.3",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {
@@ -88,6 +88,9 @@
     "config": {
         "platform": {
             "php": "7.4.0"
+        },
+        "allow-plugins": {
+            "composer/package-versions-deprecated": true
         }
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,17 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./tests/Bootstrap.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" verbose="true" stopOnFailure="false" processIsolation="false" backupGlobals="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  bootstrap="./tests/Bootstrap.php"
+  colors="true"
+  convertErrorsToExceptions="true"
+  convertNoticesToExceptions="true"
+  convertWarningsToExceptions="true"
+  verbose="true"
+  stopOnFailure="false"
+  processIsolation="false"
+  backupGlobals="false"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
+>
   <coverage includeUncoveredFiles="true">
     <include>
       <directory suffix=".php">./src</directory>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,21 +1,11 @@
 <?xml version="1.0"?>
-<phpunit
-    bootstrap="./tests/Bootstrap.php"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    verbose="true"
-    stopOnFailure="false"
-    processIsolation="false"
-    backupGlobals="false"
->
-    <testsuite name="SlmQueueDoctrine tests">
-        <directory>./tests/src</directory>
-    </testsuite>
-    <filter>
-        <whitelist addUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="./tests/Bootstrap.php" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" verbose="true" stopOnFailure="false" processIsolation="false" backupGlobals="false" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+  <coverage includeUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuite name="SlmQueueDoctrine tests">
+    <directory>./tests/src</directory>
+  </testsuite>
 </phpunit>

--- a/src/Queue/DoctrineQueue.php
+++ b/src/Queue/DoctrineQueue.php
@@ -9,8 +9,8 @@ use DateInterval;
 use DateTime;
 use DateTimeInterface;
 use DateTimeZone;
-use Doctrine\DBAL\Driver\Connection;
-use Doctrine\DBAL\DBALException;
+use Doctrine\DBAL\Connection;
+use Doctrine\DBAL\Exception as DBALException;
 use Doctrine\DBAL\LockMode;
 use Doctrine\DBAL\Types\Types;
 use SlmQueue\Job\JobInterface;
@@ -296,7 +296,7 @@ class DoctrineQueue extends AbstractQueue implements DoctrineQueueInterface
     public function peek(int $id): JobInterface
     {
         $sql  = 'SELECT * FROM ' . $this->options->getTableName() . ' WHERE id = ?';
-        $row  = $this->connection->fetchAssoc($sql, [$id], [Types::SMALLINT]);
+        $row  = $this->connection->fetchAssociative($sql, [$id], [Types::SMALLINT]);
 
         if (!$row) {
             throw new JobNotFoundException(sprintf("Job with id '%s' does not exists.", $id));

--- a/src/Queue/DoctrineQueue.php
+++ b/src/Queue/DoctrineQueue.php
@@ -68,8 +68,6 @@ class DoctrineQueue extends AbstractQueue implements DoctrineQueueInterface
      * Valid options are:
      *      - priority: the lower the priority is, the sooner the job get popped from the queue (default to 1024)
      *
-     * {@inheritDoc}
-     *
      * Note : see DoctrineQueue::parseOptionsToDateTime for schedule and delay options
      */
     public function push(JobInterface $job, array $options = []): void

--- a/src/Strategy/ClearObjectManagerStrategy.php
+++ b/src/Strategy/ClearObjectManagerStrategy.php
@@ -5,8 +5,8 @@ namespace SlmQueueDoctrine\Strategy;
 use DoctrineModule\Persistence\ObjectManagerAwareInterface as DMObjectManagerAwareInterface;
 use Laminas\EventManager\EventManagerInterface;
 use SlmQueue\Strategy\AbstractStrategy;
-use SlmQueue\Worker\Event\AbstractWorkerEvent;
 use SlmQueue\Worker\Event\ProcessJobEvent;
+use SlmQueue\Worker\Event\WorkerEventInterface;
 use SlmQueueDoctrine\Persistence\ObjectManagerAwareInterface;
 
 class ClearObjectManagerStrategy extends AbstractStrategy
@@ -17,7 +17,7 @@ class ClearObjectManagerStrategy extends AbstractStrategy
     public function attach(EventManagerInterface $events, $priority = 1): void
     {
         $this->listeners[] = $events->attach(
-            AbstractWorkerEvent::EVENT_PROCESS_JOB,
+            WorkerEventInterface::EVENT_PROCESS_JOB,
             [$this, 'onClear'],
             1000
         );

--- a/src/Strategy/IdleNapStrategy.php
+++ b/src/Strategy/IdleNapStrategy.php
@@ -5,6 +5,7 @@ namespace SlmQueueDoctrine\Strategy;
 use SlmQueue\Strategy\AbstractStrategy;
 use SlmQueue\Worker\Event\AbstractWorkerEvent;
 use SlmQueue\Worker\Event\ProcessIdleEvent;
+use SlmQueue\Worker\Event\WorkerEventInterface;
 use SlmQueueDoctrine\Queue\DoctrineQueueInterface;
 use Laminas\EventManager\EventManagerInterface;
 
@@ -33,7 +34,7 @@ class IdleNapStrategy extends AbstractStrategy
     public function attach(EventManagerInterface $events, $priority = 1): void
     {
         $this->listeners[] = $events->attach(
-            AbstractWorkerEvent::EVENT_PROCESS_IDLE,
+            WorkerEventInterface::EVENT_PROCESS_IDLE,
             [$this, 'onIdle'],
             1
         );

--- a/src/Worker/DoctrineWorker.php
+++ b/src/Worker/DoctrineWorker.php
@@ -2,15 +2,14 @@
 
 namespace SlmQueueDoctrine\Worker;
 
-use SlmQueueDoctrine\Job\Exception\ReleasableException;
-use SlmQueueDoctrine\Job\Exception\BuryableException;
-use Throwable;
 use SlmQueue\Job\JobInterface;
 use SlmQueue\Queue\QueueInterface;
 use SlmQueue\Worker\AbstractWorker;
 use SlmQueue\Worker\Event\ProcessJobEvent;
-use SlmQueueDoctrine\Job\Exception as JobException;
+use SlmQueueDoctrine\Job\Exception\BuryableException;
+use SlmQueueDoctrine\Job\Exception\ReleasableException;
 use SlmQueueDoctrine\Queue\DoctrineQueueInterface;
+use Throwable;
 
 /**
  * Worker for Doctrine
@@ -27,7 +26,7 @@ class DoctrineWorker extends AbstractWorker
         }
 
         try {
-            $job->execute($queue);
+            $job->execute();
             $queue->delete($job);
 
             return ProcessJobEvent::JOB_STATUS_SUCCESS;

--- a/tests/mezzio-runner/src/App/ConfigProvider.php
+++ b/tests/mezzio-runner/src/App/ConfigProvider.php
@@ -2,8 +2,6 @@
 
 namespace App;
 
-use Laminas\ServiceManager\AbstractFactory\ReflectionBasedAbstractFactory;
-
 class ConfigProvider
 {
     public function __invoke(): array

--- a/tests/src/Asset/OMJob.php
+++ b/tests/src/Asset/OMJob.php
@@ -8,7 +8,6 @@ use SlmQueue\Job\AbstractJob;
 
 class OMJob extends AbstractJob implements ObjectManagerAwareInterface
 {
-
     /**
      * @var ObjectManager
      */

--- a/tests/src/Asset/ThrowableJob.php
+++ b/tests/src/Asset/ThrowableJob.php
@@ -19,7 +19,6 @@
 
 namespace SlmQueueDoctrineTest\Asset;
 
-use Exception;
 use SlmQueue\Job\AbstractJob;
 
 class ThrowableJob extends AbstractJob
@@ -27,7 +26,7 @@ class ThrowableJob extends AbstractJob
     /**
      * {@inheritDoc}
      */
-    public function execute(): ?int
+    public function execute()
     {
         $undefined->acces();
     }

--- a/tests/src/Strategy/ClearObjectManagerStrategyTest.php
+++ b/tests/src/Strategy/ClearObjectManagerStrategyTest.php
@@ -7,8 +7,8 @@ use Laminas\EventManager\EventManagerInterface;
 use PHPUnit\Framework\TestCase;
 use SlmQueue\Queue\QueueInterface;
 use SlmQueue\Strategy\AbstractStrategy;
-use SlmQueue\Worker\Event\AbstractWorkerEvent;
 use SlmQueue\Worker\Event\ProcessJobEvent;
+use SlmQueue\Worker\Event\WorkerEventInterface;
 use SlmQueueDoctrine\Strategy\ClearObjectManagerStrategy;
 use SlmQueueDoctrine\Worker\DoctrineWorker;
 use SlmQueueDoctrineTest\Asset\OMJob;
@@ -38,7 +38,7 @@ class ClearObjectManagerStrategyTest extends TestCase
         $priority = 1;
 
         $evm->expects($this->once())->method('attach')
-            ->with(AbstractWorkerEvent::EVENT_PROCESS_JOB, [$this->listener, 'onClear'], 1000);
+            ->with(WorkerEventInterface::EVENT_PROCESS_JOB, [$this->listener, 'onClear'], 1000);
 
         $this->listener->attach($evm, $priority);
     }

--- a/tests/src/Strategy/ClearObjectManagerStrategyTest.php
+++ b/tests/src/Strategy/ClearObjectManagerStrategyTest.php
@@ -37,8 +37,11 @@ class ClearObjectManagerStrategyTest extends TestCase
         $evm = $this->createMock(EventManagerInterface::class);
         $priority = 1;
 
-        $evm->expects($this->once())->method('attach')
-            ->with(WorkerEventInterface::EVENT_PROCESS_JOB, [$this->listener, 'onClear'], 1000);
+        $evm->expects($this->once())->method('attach')->with(
+            WorkerEventInterface::EVENT_PROCESS_JOB,
+            [$this->listener, 'onClear'],
+            1000
+        );
 
         $this->listener->attach($evm, $priority);
     }

--- a/tests/src/Strategy/ClearObjectManagerStrategyTest.php
+++ b/tests/src/Strategy/ClearObjectManagerStrategyTest.php
@@ -37,7 +37,7 @@ class ClearObjectManagerStrategyTest extends TestCase
         $evm = $this->createMock(EventManagerInterface::class);
         $priority = 1;
 
-        $evm->expects($this->at(0))->method('attach')
+        $evm->expects($this->once())->method('attach')
             ->with(AbstractWorkerEvent::EVENT_PROCESS_JOB, [$this->listener, 'onClear'], 1000);
 
         $this->listener->attach($evm, $priority);

--- a/tests/src/Strategy/IdleNapStrategyTest.php
+++ b/tests/src/Strategy/IdleNapStrategyTest.php
@@ -6,8 +6,8 @@ use Laminas\EventManager\EventManagerInterface;
 use PHPUnit\Framework\TestCase;
 use SlmQueue\Queue\QueueInterface;
 use SlmQueue\Strategy\AbstractStrategy;
-use SlmQueue\Worker\Event\AbstractWorkerEvent;
 use SlmQueue\Worker\Event\ProcessIdleEvent;
+use SlmQueue\Worker\Event\WorkerEventInterface;
 use SlmQueueDoctrine\Queue\DoctrineQueueInterface;
 use SlmQueueDoctrine\Strategy\IdleNapStrategy;
 use SlmQueueDoctrine\Worker\DoctrineWorker;
@@ -37,7 +37,7 @@ class IdleNapStrategyTest extends TestCase
         $priority = 1;
 
         $evm->expects($this->once())->method('attach')
-            ->with(AbstractWorkerEvent::EVENT_PROCESS_IDLE, [$this->listener, 'onIdle'], 1);
+            ->with(WorkerEventInterface::EVENT_PROCESS_IDLE, [$this->listener, 'onIdle'], 1);
 
         $this->listener->attach($evm, $priority);
     }

--- a/tests/src/Strategy/IdleNapStrategyTest.php
+++ b/tests/src/Strategy/IdleNapStrategyTest.php
@@ -36,8 +36,11 @@ class IdleNapStrategyTest extends TestCase
         $evm = $this->createMock(EventManagerInterface::class);
         $priority = 1;
 
-        $evm->expects($this->once())->method('attach')
-            ->with(WorkerEventInterface::EVENT_PROCESS_IDLE, [$this->listener, 'onIdle'], 1);
+        $evm->expects($this->once())->method('attach')->with(
+            WorkerEventInterface::EVENT_PROCESS_IDLE,
+            [$this->listener, 'onIdle'],
+            1
+        );
 
         $this->listener->attach($evm, $priority);
     }

--- a/tests/src/Strategy/IdleNapStrategyTest.php
+++ b/tests/src/Strategy/IdleNapStrategyTest.php
@@ -36,7 +36,7 @@ class IdleNapStrategyTest extends TestCase
         $evm = $this->createMock(EventManagerInterface::class);
         $priority = 1;
 
-        $evm->expects($this->at(0))->method('attach')
+        $evm->expects($this->once())->method('attach')
             ->with(AbstractWorkerEvent::EVENT_PROCESS_IDLE, [$this->listener, 'onIdle'], 1);
 
         $this->listener->attach($evm, $priority);

--- a/tests/src/Worker/DoctrineWorkerTest.php
+++ b/tests/src/Worker/DoctrineWorkerTest.php
@@ -2,14 +2,13 @@
 
 namespace SlmQueueDoctrineTest\Worker;
 
+use Laminas\EventManager\EventManager;
+use Laminas\ServiceManager\ServiceManager;
 use PHPUnit\Framework\TestCase as TestCase;
 use SlmQueue\Strategy\MaxRunsStrategy;
 use SlmQueueDoctrine\Queue\DoctrineQueueInterface;
-use SlmQueueDoctrineTest\Asset;
 use SlmQueueDoctrine\Worker\DoctrineWorker;
-use SlmQueueDoctrineTest\Util\ServiceManagerFactory;
-use Laminas\EventManager\EventManager;
-use Laminas\ServiceManager\ServiceManager;
+use SlmQueueDoctrineTest\Asset;
 
 class DoctrineWorkerTest extends TestCase
 {


### PR DESCRIPTION
- Allows and tests PHP 8.1.
- Bumps `doctrine/dbal` requirement to ^3.0, fixing type deprecations in `DoctrineQueue`.
- Bumps `phpunit/phpunit` requirement to ^9.3. Updates `phpunit.xml` to new format.
- Fixes `at()` matcher deprecations in PHPUnit.